### PR TITLE
Added deep overrides of secrets

### DIFF
--- a/confidential/secrets_manager.py
+++ b/confidential/secrets_manager.py
@@ -7,20 +7,22 @@ import boto3
 import click
 from botocore.exceptions import ClientError
 
+from confidential.utils import merge
+
 log = logging.getLogger(__name__)
 
 
 class SecretsManager:
-    def __init__(self, secret_file=None, secrets_file_default=None, region_name=None):
+    def __init__(self, secrets_file=None, secrets_file_default=None, region_name=None):
         session = boto3.session.Session()
 
         self.session = session
         self.client = session.client(service_name="secretsmanager", region_name=region_name)
 
         secrets_defaults = self.parse_secrets_file(secrets_file_default) if secrets_file_default else {}
-        secrets = self.parse_secrets_file(secret_file) if secret_file else {}
+        secrets = self.parse_secrets_file(secrets_file) if secrets_file else {}
 
-        self.secrets = {**secrets_defaults, **secrets}
+        self.secrets = merge(secrets_defaults, secrets)
 
     def __getitem__(self, key):
         """

--- a/confidential/utils.py
+++ b/confidential/utils.py
@@ -1,4 +1,4 @@
-def merge(initial: dict, overrides: dict, path=None) -> dict:
+def merge(initial: dict, overrides: dict) -> dict:
     """
     Merges overrides into initial
 
@@ -6,13 +6,10 @@ def merge(initial: dict, overrides: dict, path=None) -> dict:
     :param overrides: <dict>
     :return: Merged <dict>
     """
-    if path is None:
-        path = []
-
     for key in overrides:
         if key in initial:
             if isinstance(initial[key], dict) and isinstance(overrides[key], dict):
-                merge(initial[key], overrides[key], path + [str(key)])
+                merge(initial[key], overrides[key])
             else:
                 initial[key] = overrides[key]
         else:

--- a/confidential/utils.py
+++ b/confidential/utils.py
@@ -1,0 +1,21 @@
+def merge(initial: dict, overrides: dict, path=None) -> dict:
+    """
+    Merges overrides into initial
+
+    :param initial: <dict>
+    :param overrides: <dict>
+    :return: Merged <dict>
+    """
+    if path is None:
+        path = []
+
+    for key in overrides:
+        if key in initial:
+            if isinstance(initial[key], dict) and isinstance(overrides[key], dict):
+                merge(initial[key], overrides[key], path + [str(key)])
+            else:
+                initial[key] = overrides[key]
+        else:
+            initial[key] = overrides[key]
+
+    return initial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "confidential"
-version = "1.1.2"
+version = "2.0.0"
 description = "Manage secrets in your projects using AWS Secrets Manager"
 authors = ["Daniel van Flymen <dvf@candidco.com>", "Elliott Chartock <elliott.chartock@candidco.com>"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+from confidential.utils import merge
+
+
+def test_combine():
+    initial = {"dang": "bang", "foo": "bar", "node": {"a": "1", "b": "1", "c": {"something": "else"}}}
+    overrides = {"foo": "boo", "key_not_in_initial": 3, "node": {"b": "2", "c": "3"}}
+
+    merged = merge(initial, overrides)
+
+    assert merged["dang"] == "bang"
+    assert merged["foo"] == "boo"
+    assert merged["key_not_in_initial"] == 3
+    assert merged["node"]["a"] == "1"
+    assert merged["node"]["b"] == "2"
+    assert merged["node"]["c"] == "3"


### PR DESCRIPTION
Secrets files can now be deeply-merged:

```json
# defaults.json
{
  "django": {
    "debug": true,
    "database": {
      "hostname": "123",
      "port": 8000,
    }
  }
}
```

```json
# overrides.json
{
  "django": {
    "database": {
      "hostname": "456",
    }
  }
}
```

**Result:**
```json
{
  "django": {
    "debug": true,
    "database": {
      "hostname": "456",
      "port": 8000,
    }
  }
}
```

Also fixed a minor typo.