### PR TITLE
add optional profile parameter

### DIFF
--- a/confidential/__init__.py
+++ b/confidential/__init__.py
@@ -1,4 +1,4 @@
 from confidential.secrets_manager import SecretsManager
 
 __all__ = ["SecretsManager"]
-__version__ = "1.1.0"
+__version__ = "1.0.0"

--- a/confidential/__init__.py
+++ b/confidential/__init__.py
@@ -1,4 +1,4 @@
 from confidential.secrets_manager import SecretsManager
 
 __all__ = ["SecretsManager"]
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/confidential/secrets_manager.py
+++ b/confidential/secrets_manager.py
@@ -12,8 +12,8 @@ log = logging.getLogger(__name__)
 
 
 class SecretsManager:
-    def __init__(self, secrets_file=None, secrets_file_default=None, region_name=None):
-        session = boto3.session.Session()
+    def __init__(self, secrets_file=None, secrets_file_default=None, region_name=None, profile_name=None):
+        session = boto3.session.Session(profile_name=profile_name)
 
         self.session = session
         self.client = session.client(service_name="secretsmanager", region_name=region_name)
@@ -110,11 +110,12 @@ class SecretsManager:
 @click.command()
 @click.argument("secrets_file", type=click.Path(exists=True))
 @click.option("--default_secrets_file", default=None, help="A default secrets file that will be overridden")
+@click.option("-p", "--profile", default=None, help="AWS Profile")
 @click.option("--aws_region", help="AWS Region", default="us-east-1")
 @click.option("--output-json", help="Return secrets as JSON", is_flag=True)
-def decrypt_secret(secrets_file, default_secrets_file, aws_region, output_json):
+def decrypt_secret(secrets_file, default_secrets_file, profile, aws_region, output_json):
     pp = pprint.PrettyPrinter(indent=4)
-    secrets_manager = SecretsManager(secrets_file, default_secrets_file, aws_region)
+    secrets_manager = SecretsManager(secrets_file=secrets_file, secrets_file_default=default_secrets_file, region_name=aws_region, profile_name=profile)
     if output_json is True:
         print(json.dumps(secrets_manager.secrets))
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "confidential"
-version = "2.1.1"
+version = "2.2.0"
 description = "Manage secrets in your projects using AWS Secrets Manager"
 authors = [
     "Daniel van Flymen <dvf@candidco.com>",


### PR DESCRIPTION
## What does this do?
Adds an optional parameter (`-p`,`--profile`) to allow the user to pass in an alternative profile.

## Why did you do this?
The current configuration limits confidential to the default profile. For users with multiple profiles, they may wish to use confidential with something beyond the default profile.

## How did you test this change?
Ran with a known working profile, with a known non-working profile, with a profile that doesn't exist, and lastly, with no profile specified at all.

## etc
I had thought of catching the exception raised when a profile is specified but could not be found (`botocore.exceptions.ProfileNotFound`) but found the error message to be descriptive enough on its own.

ex:
```
botocore.exceptions.ProfileNotFound: The config profile (candidco) could not be found
```