### PR TITLE
add private pypi push

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,8 @@ jobs:
         python-version: [3.6, 3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -25,6 +26,12 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
     - name: Push to s3
       env:
         AWS_S3_BUCKET: pypi.candidco.com

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,4 +31,6 @@ jobs:
         SOURCE_DIR: "."
       run: |
         pip install s3pypi==0.11.0
+        pip install poetry2setup
+        poetry2setup > setup.py
         s3pypi --bucket pypi.candidco.com --private

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,3 +25,10 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Push to s3
+      env:
+        AWS_S3_BUCKET: pypi.candidco.com
+        SOURCE_DIR: "."
+      run: |
+        pip install s3pypi==0.11.0
+        s3pypi --bucket pypi.candidco.com --private

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,7 +3,7 @@ name: pytest
 on: [push]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:
@@ -26,18 +26,29 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
-    - name: Push to s3
-      env:
-        AWS_S3_BUCKET: pypi.candidco.com
-        SOURCE_DIR: "."
-      run: |
-        pip install s3pypi==0.11.0
-        pip install poetry2setup
-        poetry2setup > setup.py
-        s3pypi --bucket pypi.candidco.com --private
+
+  build_and_deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/master' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Push to s3
+        env:
+          AWS_S3_BUCKET: pypi.candidco.com
+          SOURCE_DIR: "."
+        run: |
+          pip install s3pypi
+          pip install poetry2setup
+          poetry2setup > setup.py
+          s3pypi --bucket pypi.candidco.com --private || echo "ERROR: push failed for $package";


### PR DESCRIPTION
## what

Adds push to private pypi.

## why

Confidential was apparently pushed manually to pypi using dvf's account. Until we get that access we should push to our internal pypi so that we can still iterate.