### PR TITLE
Export env variables and return None for inexistent key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ DATABASES = {
 }
 ```
 
+If `export_env_variables` is set to `True`, each secret will also be exported as an environment variable, with the uppercase key as the variable name, e.g.:
+
+```python
+from confidential import SecretsManager
+import os
+
+secrets = SecretManager(
+    secrets_file=".secrets/production.json",
+    secrets_file_default=".secrets/defaults.json",  # Overridable defaults you can use in common environments
+    region_name="us-east-1",
+    export_env_variables=True,  # Optionally, export secrets as environment variables. Default is False.
+)
+
+# If the key of a secret is `api_key`, then the following is true:
+assert secrets["api_key"] == os.environ.get("API_KEY")
+```
+
+Trying to access an inexisting key returns `None`. On previous versions, it would throw an exception.
+
 # Testing
 
 First, install all dependencies:

--- a/confidential/secrets_manager.py
+++ b/confidential/secrets_manager.py
@@ -36,7 +36,7 @@ class SecretsManager:
         """
         value = self.secrets.get(key)
         if value is None:
-            log.warning(f"Value for '{key}' was not found in the secrets file. Returning 'None'.", self.secrets)
+            log.warning(f"Value for '{key}' was not found in the secrets file. Returning 'None'.")
         return value
 
     @staticmethod

--- a/confidential/secrets_manager.py
+++ b/confidential/secrets_manager.py
@@ -4,11 +4,9 @@ import json
 import logging
 import os
 import pprint
-from botocore.exceptions import ClientError
 
 from confidential.secrets_manager_decrypter import SecretsManagerDecrypter
 from confidential.parameter_store_decrypter import ParameterStoreDecrypter
-from confidential.exceptions import PermissionError
 from confidential.utils import merge
 
 log = logging.getLogger(__name__)

--- a/confidential/secrets_manager.py
+++ b/confidential/secrets_manager.py
@@ -35,7 +35,7 @@ class SecretsManager:
         """
         value = self.secrets.get(key)
         if value is None:
-            raise Exception(f"Value for '{key}' was not found in the secrets file", self.secrets)
+            log.warning(f"Value for '{key}' was not found in the secrets file. Returning 'None'.", self.secrets)
         return value
 
     @staticmethod

--- a/confidential/secrets_manager.py
+++ b/confidential/secrets_manager.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 class SecretsManager:
-    def __init__(self, secrets_file=None, secrets_file_default=None, region_name=None, profile_name=None):
+    def __init__(self, secrets_file=None, secrets_file_default=None, region_name=None, profile_name=None, export_env_variables=False):
         session = boto3.session.Session(profile_name=profile_name)
 
         self.session = session
@@ -28,6 +28,9 @@ class SecretsManager:
         secrets = self.parse_secrets_file(secrets_file) if secrets_file else {}
 
         self.secrets = merge(secrets_defaults, secrets)
+
+        if export_env_variables:
+            self.export_env_variables(self.secrets)
 
     def __getitem__(self, key):
         """
@@ -93,6 +96,11 @@ class SecretsManager:
         self.traverse_and_decrypt(config)
 
         return config
+
+    def export_env_variables(self, secrets):
+        for key in secrets:
+            uppercase_key = key.upper()
+            os.environ[uppercase_key] = str(secrets[key])
 
 
 @click.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "confidential"
-version = "2.4.0"
+version = "2.5.0"
 description = "Manage secrets in your projects using AWS Secrets Manager"
 authors = [
     "Daniel van Flymen <dvf@candidco.com>",


### PR DESCRIPTION
Introduce the `export_env_variables` parameter to `SecretsManager`. If `export_env_variables` is set to `True`, each secret will also be exported as an environment variable, with the uppercase key as the variable name.

Trying to access an inexistent key now returns `None`. On previous versions, it would throw an exception.