### PR TITLE
Wrap decrypt errors in DecryptFromAWSError Exception

### DIFF
--- a/confidential/exceptions.py
+++ b/confidential/exceptions.py
@@ -1,2 +1,2 @@
-class PermissionError(Exception):
+class DecryptFromAWSError(Exception):
     pass

--- a/confidential/secrets_manager.py
+++ b/confidential/secrets_manager.py
@@ -7,6 +7,7 @@ import pprint
 
 from confidential.secrets_manager_decrypter import SecretsManagerDecrypter
 from confidential.parameter_store_decrypter import ParameterStoreDecrypter
+from confidential.exceptions import DecryptFromAWSError
 from confidential.utils import merge
 
 log = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "confidential"
-version = "2.5.0"
+version = "2.6.0"
 description = "Manage secrets in your projects using AWS Secrets Manager"
 authors = [
     "Daniel van Flymen <dvf@candidco.com>",

--- a/tests/test_secrets_manager.py
+++ b/tests/test_secrets_manager.py
@@ -2,7 +2,7 @@ import pytest
 import os
 
 from confidential import SecretsManager
-from confidential.exceptions import PermissionError
+from confidential.exceptions import DecryptFromAWSError
 
 
 def test_happy_path(secrets_file):
@@ -24,12 +24,13 @@ def test_happy_path(secrets_file):
     # Check SSM parameter decoding
     assert secrets["parameter_key"] == "ssm_parameter_value"
     assert secrets["nested_object_parameter"] == {"ping": "pong"}
-    assert secrets["nested_parameter_key"] == {"temp_c": 3, "snow_fall_cm": 20, "some_parameter": "cold" }
+    assert secrets["nested_parameter_key"] == {"temp_c": 3, "snow_fall_cm": 20, "some_parameter": "cold"}
+
 
 def test_secrets_exported_to_env_vars(secrets_file):
     with secrets_file(foo="bar", ping="pong") as f:
         secrets = SecretsManager(f, region_name="us-west-1", export_env_variables=True)
-    
+
     assert os.environ.get("FOO") == "bar"
     assert secrets["foo"] == os.environ.get("FOO")
 
@@ -37,19 +38,60 @@ def test_secrets_exported_to_env_vars(secrets_file):
     assert secrets["ping"] == os.environ.get("PING")
 
     assert os.environ.get("blah") == None
-    assert secrets["blah"] == os.environ.get("BLAH") 
+    assert secrets["blah"] == os.environ.get("BLAH")
 
-@pytest.mark.parametrize("secret_value_response", [{"FakeKey": "FakeValue"}, {"SecretString": None}])
-def test_missing_secret_string_raises_permission_error(secret_value_response, mocker, secrets_file):
+
+@pytest.mark.parametrize(
+    "secret_value_response,error_msg",
+    [
+        (
+            {"FakeKey": "FakeValue"},
+            "Error decrypting SecretId=keep_it_secret. `SecretString` not found in AWS response. Does the IAM user have correct permissions?",
+        ),
+        (
+            {"SecretString": None},
+            "Error decrypting SecretId=keep_it_secret. `SecretString` was `None`. Does the IAM user have correct permissions?",
+        ),
+    ],
+)
+def test_missing_or_none_secret_string_raises_decrypt_from_aws_error(secret_value_response, error_msg, mocker, secrets_file):
     mock_boto = mocker.patch("confidential.secrets_manager.boto3.session.Session")
     client_mock = mocker.Mock()
     client_mock.client.return_value.get_secret_value.return_value = secret_value_response
     mock_boto.return_value = client_mock
 
-    with pytest.raises(PermissionError) as exc_info:
+    with pytest.raises(DecryptFromAWSError) as exc_info:
         with secrets_file() as f:
             SecretsManager(f, region_name="us-west-1")
 
-    assert (
-        str(exc_info.value) == "`SecretString` not found in AWS response, does the IAM user have correct permissions?"
-    )
+    assert str(exc_info.value) == error_msg
+
+
+@pytest.mark.parametrize(
+    "secret_value_response,error_msg",
+    [
+        (
+            {"FakeKey": "FakeValue"},
+            "Error decrypting Name=parameter_key. `Parameter.Value` not found in AWS response. Does the IAM user have correct permissions?",
+        ),
+        (
+            {"Parameter": {"FakeKey": "FakeValue"}},
+            "Error decrypting Name=parameter_key. `Parameter.Value` not found in AWS response. Does the IAM user have correct permissions?",
+        ),
+        (
+            {"Parameter": {"Value": None}},
+            "Error decrypting Name=parameter_key. `Parameter.Value` was `None`. Does the IAM user have correct permissions?",
+        ),
+    ],
+)
+def test_missing_or_none_parameter_value_raises_decrypt_from_aws_error(secret_value_response, error_msg, mocker, ssm_params_file):
+    mock_boto = mocker.patch("confidential.secrets_manager.boto3.session.Session")
+    client_mock = mocker.Mock()
+    client_mock.client.return_value.get_parameter.return_value = secret_value_response
+    mock_boto.return_value = client_mock
+
+    with pytest.raises(DecryptFromAWSError) as exc_info:
+        with ssm_params_file() as f:
+            SecretsManager(f, region_name="us-west-1")
+
+    assert str(exc_info.value) == error_msg


### PR DESCRIPTION
A previous change allowed to return `None` for a secret's value and broke `confidential/secrets_manager.py` when it [tried to deserialize a secret value](https://github.com/candidco/confidential/blob/8d8a457c3cbe2f41de2fea277ae2e2e34e4f057f/confidential/secrets_manager.py#L76):
```python
result = json.loads(decrypted_string)
```
This PR fixes that, raising a DecryptFromAWSError exception. It also improves error handling, adding info about the configuration key name being read when exceptions occur.

Unit tests were updated to test the `secretsmanager` and `ssm` client responses individually.